### PR TITLE
Speed up bam splitting for bcall

### DIFF
--- a/mgatk/bin/python/split_barcoded_bam.py
+++ b/mgatk/bin/python/split_barcoded_bam.py
@@ -30,7 +30,7 @@ def writePassingReads(bc_dict, mtchr):
 	'''
 	Write out reads to their corresponding files based on a barcode index
 	'''
-	bam = pysam.AlignmentFile(bamfile,'rb', threads=5)
+	bam = pysam.AlignmentFile(bamfile,'rb')
 	Itr = bam.fetch(str(mtchr),multiple_iterators=False)
 	for read in Itr:
 		read_barcode = getBarcode(read)

--- a/mgatk/bin/python/split_barcoded_bam.py
+++ b/mgatk/bin/python/split_barcoded_bam.py
@@ -16,35 +16,35 @@ mtchr = sys.argv[5]
 base=os.path.basename(bamfile)
 basename=os.path.splitext(base)[0]
 
-def getBarcode(intags):
+def getBarcode(read):
 	'''
 	Parse out the barcode per-read
 	'''
-	for tg in intags:
-		if(barcodeTag == tg[0]):
-			return(tg[1])
-	return("NA")
+	if read.has_tag(barcodeTag):
+		return read.get_tag(barcodeTag)
+	else:
+		return "NA"
 
 
-def writePassingReads(bc, mtchr):
+def writePassingReads(bc_dict, mtchr):
 	'''
 	Write out reads to their corresponding files based on a barcode index
 	'''
-	bam = pysam.AlignmentFile(bamfile,'rb')
+	bam = pysam.AlignmentFile(bamfile,'rb', threads=5)
 	Itr = bam.fetch(str(mtchr),multiple_iterators=False)
 	for read in Itr:
-		read_barcode = getBarcode(read.tags)
+		read_barcode = getBarcode(read)
 		
 		# If read barcode is in whitelist, then write it out
-		if read_barcode in bc:
-			idx = bc.index(read_barcode)
+		if read_barcode in bc_dict:
+			idx = bc_dict[read_barcode]
 			file = fopen[idx]
 			file.write(read)
 
 # Read in the barcodes
 with open(bcfile) as barcode_file_handle:
     content = barcode_file_handle.readlines()
-bc = [x.strip() for x in content] 
+bc = [x.strip() for x in content]
 
 # Open up a bunch of files and write out reads for valid barcodes
 @contextmanager
@@ -61,8 +61,9 @@ def multi_file_manager(files, mode='rt'):
 		
 # Final loop to write out passing reads
 bambcfiles = [outfolder + "/" + bc1 + ".bam" for bc1 in bc]
+bc_dict = {bc1: i  for i,bc1 in enumerate(bc)}
 with multi_file_manager(bambcfiles) as fopen:
-	writePassingReads(bc, mtchr)
+	writePassingReads(bc_dict, mtchr)
 
 
 


### PR DESCRIPTION
I made two changes to split_barcoded_bam.py which speeds it up roughly 10-fold:

- Uses has_tag and get_tag to fetch the barcode per read, instead of iterating over all tags.
- Constructs a dictionary to match the read barcode to the whitelist (dictionary keys) and fetches the correct file by using that dictionary, instead of checking if the barcode is in a list and then getting the list index value for that barcode.

Both changes turn these two tasks from linear-time to constant-time operations, thereby speeding up the overall code.

Best,
Anton