### PR TITLE
Replace `np.float` with `np.float64` to address deprecation

### DIFF
--- a/mgatk/bin/python/variant_calling.py
+++ b/mgatk/bin/python/variant_calling.py
@@ -156,7 +156,7 @@ variant_output.columns = ['position', 'nucleotide', 'variant', 'vmr', 'mean', 'v
                           'n_cells_over_10', 'n_cells_over_20', 'n_cells_over_95',
                           'max_heteroplasmy', 'strand_correlation', 'mean_coverage']
 variant_output[['vmr', 'mean', 'variance', 'strand_correlation', 'mean_coverage', 'max_heteroplasmy']] = variant_output[['vmr', 'mean', 'variance', 'strand_correlation',
-                                                                                                                         'mean_coverage', 'max_heteroplasmy']].astype(np.float)
+                                                                                                                         'mean_coverage', 'max_heteroplasmy']].astype(np.float64)
 
 # exclude variants with less than three cells
 multi_cell_variants = variant_output[variant_output['n_cells_conf_detected'] >= 3]['variant']


### PR DESCRIPTION
`np.float` was deprecated in NumPy v1.20 and removed in v1.24. Using mgatk with the latest NumPy release causes an error, resulting in the absence of output files such as `*.variant_stats.tsv.gz` and `*.cell_heteroplasmic_df.tsv.gz`.