### PR TITLE
Support gzipped barcode files

### DIFF
--- a/mgatk/mgatkHelp.py
+++ b/mgatk/mgatkHelp.py
@@ -5,6 +5,7 @@ import re
 import os
 import sys
 import subprocess
+import gzip
 import pysam
 import filecmp
 import math
@@ -161,11 +162,14 @@ def make_folder(folder):
 	if not os.path.exists(folder):
 		os.makedirs(folder)
 
+def _open_barcode_file(fname):
+	if fname.endswith(".gz"):
+		return gzip.open(fname, "rt")
+	return open(fname)
+
 def file_len(fname):
-    with open(fname) as f:
-        for i, l in enumerate(f):
-            pass
-    return i + 1
+    with _open_barcode_file(fname) as f:
+        return sum(1 for _ in f)
 
 def split_barcodes_file(barcode_file, nsamples, output):
 	"""
@@ -174,19 +178,19 @@ def split_barcodes_file(barcode_file, nsamples, output):
 	n_samples_observed = file_len(barcode_file)
 	
 	# See if we need to do anything... if user didn't specify or we have relatively few samples, just return the barcode file back
-	if(n_samples_observed < nsamples or nsamples == 0):
+	if((n_samples_observed < nsamples or nsamples == 0) and not barcode_file.endswith(".gz")):
 		return([barcode_file])
 	else:
 		# Need to split files into a maximum of n samples
-		total_files = math.ceil(n_samples_observed / nsamples)
-		lines_per_file = nsamples
+		lines_per_file = nsamples if nsamples else max(n_samples_observed, 1)
+		total_files = math.ceil(n_samples_observed / lines_per_file)
 		
 		# Set up a temporary output folder to route files to
 		full_output_folder = output + "/temp" + "/barcode_files"
 		make_folder(full_output_folder)
 		smallfile = None
 		counter = 0
-		with open(barcode_file) as bigfile:
+		with _open_barcode_file(barcode_file) as bigfile:
 			for lineno, line in enumerate(bigfile):
 				if lineno % lines_per_file == 0:
 					if smallfile:

--- a/tests/test_barcode_files.py
+++ b/tests/test_barcode_files.py
@@ -1,0 +1,36 @@
+import gzip
+from pathlib import Path
+
+from mgatk.mgatkHelp import file_len, split_barcodes_file
+
+
+def test_file_len_reads_gzipped_barcode_files(tmp_path):
+    barcodes = tmp_path / "barcodes.tsv.gz"
+    with gzip.open(barcodes, "wt") as handle:
+        handle.write("AAAC\nGGGT\n")
+
+    assert file_len(str(barcodes)) == 2
+
+
+def test_split_barcodes_file_decompresses_gzip_without_splitting(tmp_path):
+    barcodes = tmp_path / "barcodes.tsv.gz"
+    with gzip.open(barcodes, "wt") as handle:
+        handle.write("AAAC\nGGGT\n")
+
+    split_files = split_barcodes_file(str(barcodes), 0, str(tmp_path / "out"))
+
+    assert len(split_files) == 1
+    assert Path(split_files[0]).read_text() == "AAAC\nGGGT\n"
+
+
+def test_split_barcodes_file_splits_gzipped_barcodes(tmp_path):
+    barcodes = tmp_path / "barcodes.tsv.gz"
+    with gzip.open(barcodes, "wt") as handle:
+        handle.write("AAAC\nGGGT\nTTTA\n")
+
+    split_files = split_barcodes_file(str(barcodes), 2, str(tmp_path / "out"))
+
+    assert [Path(filename).read_text() for filename in split_files] == [
+        "AAAC\nGGGT\n",
+        "TTTA\n",
+    ]


### PR DESCRIPTION
## Summary
- Read barcode lists with `gzip.open(..., rt)` when the file path ends in `.gz`.
- Normalize gzipped barcode lists into the existing temporary `.txt` barcode chunks so downstream scripts can keep using normal text files.
- Add regression coverage for counting and splitting gzipped barcode files.

Fixes #106.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Not run locally: test suite